### PR TITLE
Make console more robust to typos

### DIFF
--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -123,6 +123,14 @@ func before(c *cli.Context) error {
 	return nil
 }
 
+// badCmd is called when we invoke with an invalid first argument (just for console for now)
+func badCmd(c *cli.Context, cmd string) {
+	fmt.Println("Unknown command:", cmd)
+	fmt.Println("Please try one of the following:")
+	fmt.Println("")
+	cli.DefaultAppComplete(c)
+}
+
 //--------------------------------------------------------------------------------
 
 func cmdBatch(app *cli.App, c *cli.Context) error {
@@ -149,6 +157,8 @@ func cmdBatch(app *cli.App, c *cli.Context) error {
 }
 
 func cmdConsole(app *cli.App, c *cli.Context) error {
+	// don't hard exit on mistyped commands (eg. check vs check_tx)
+	app.CommandNotFound = badCmd
 	for {
 		fmt.Printf("\n> ")
 		bufReader := bufio.NewReader(os.Stdin)
@@ -162,10 +172,10 @@ func cmdConsole(app *cli.App, c *cli.Context) error {
 		args := []string{"tmsp-cli"}
 		args = append(args, strings.Split(string(line), " ")...)
 		if err := app.Run(args); err != nil {
-			return err
+			// if the command doesn't succeed, inform the user without exiting
+			fmt.Println("Error:", err.Error())
 		}
 	}
-	return nil
 }
 
 // Have the application echo a message


### PR DESCRIPTION
If I make a typeo in the console, it will die.  Both forgetting to pass an argument to `query` as well as a typo `check` not `check_tx`.  This is not user-friendly.

As I am playing with tmsp-cli as a way to debug and understand apps, I added error messages to replace exit cases.

I'd also like to add readline support (like auto-complete, up arrow to go through buffer history), but that is another project.  Let me know if you would like that.