### PR TITLE
Update grpc version again.

### DIFF
--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -1326,7 +1326,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for TMSPApplication service
 


### PR DESCRIPTION
As of 2016/03/11  new mintnet deploys break here:

github.com/tendermint/tmsp/types
/go/src/github.com/tendermint/tmsp/types/types.pb.go:1329: undefined: grpc.SupportPackageIsVersion3
/data/tendermint/data/init.sh: line 6: merkleeyes: command not found

