### PR TITLE
Updates, Closes #40, Closes #35

### DIFF
--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -19,6 +19,10 @@ import (
 var client tmspcli.Client
 
 func main() {
+
+	//workaround for the cli library (https://github.com/urfave/cli/issues/565)
+	cli.OsExiter = func(_ int) {}
+
 	app := cli.NewApp()
 	app.Name = "tmsp-cli"
 	app.Usage = "tmsp-cli [command] [args...]"
@@ -171,10 +175,7 @@ func cmdConsole(app *cli.App, c *cli.Context) error {
 
 		args := []string{"tmsp-cli"}
 		args = append(args, strings.Split(string(line), " ")...)
-		if err := app.Run(args); err != nil {
-			// if the command doesn't succeed, inform the user without exiting
-			fmt.Println("Error:", err.Error())
-		}
+		app.Run(args) //cli already prints error within its func call
 	}
 }
 

--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -16,31 +16,41 @@ import (
 	"github.com/urfave/cli"
 )
 
-// client is a global variable so it can be reused by the console
-var client tmspcli.Client
-
 //structure for data passed to print response
-type PR struct {
-	res       types.Result
-	s         string
-	printCode bool
-	code      string
+// variables must be exposed for JSON to read
+type pr struct {
+	Res       types.Result
+	S         string
+	PrintCode bool
+	Code      string
 }
 
-func newPR(res types.Result, s string, printCode bool) PR {
-	pr := PR{
-		res:       res,
-		s:         s,
-		printCode: printCode,
-		code:      "",
+//trivial implementation of Error for JSON prints
+type er struct {
+	Error string
+}
+
+func newPr(res types.Result, s string, printCode bool) *pr {
+	out := &pr{
+		Res:       res,
+		S:         s,
+		PrintCode: printCode,
+		Code:      "",
 	}
 
 	if printCode {
-		pr.code = res.Code.String()
+		out.Code = res.Code.String()
 	}
 
-	return pr
+	return out
 }
+
+func newEr(err error) *er {
+	return &er{Error: err.Error()}
+}
+
+// client is a global variable so it can be reused by the console
+var client tmspcli.Client
 
 func main() {
 
@@ -157,29 +167,25 @@ func before(c *cli.Context) error {
 
 // badCmd is called when we invoke with an invalid first argument (just for console for now)
 func badCmd(c *cli.Context, cmd string) {
+	if c.GlobalBool("mro") {
+		printJSON(newEr(errors.New("Unknown command")))
+		return
+	}
+
 	fmt.Println("Unknown command:", cmd)
 	fmt.Println("Please try one of the following:")
 	fmt.Println("")
 	cli.DefaultAppComplete(c)
 }
 
-//Generates new Args array based off of original Args call to maintain flag persistence
-func persistentArgs(removeArg string, line []byte) []string {
-	//function to remove first slice of matching string from string array
-	remove := func(slice []string, removeText string) []string {
-		for i := len(slice) - 1; i >= 0; i-- { //search from end to start
-			if slice[i] == removeText {
-				return append(slice[:i], slice[i+1:]...)
-			}
-		}
-		return slice
-	}
+//Generates new Args array based off of previous call args to maintain flag persistence
+func persistentArgs(line []byte) []string {
 
 	//generate the arguments to run from orginal os.Args
 	// to maintain flag arguments
 	args := os.Args
-	fmt.Println(args)
-	args = remove(args, removeArg)
+	args = args[:len(args)-1] // remove the previous command argument
+
 	if len(line) > 0 { //prevents introduction of extra space leading to argument parse errors
 		args = append(args, strings.Split(string(line), " ")...)
 	}
@@ -202,10 +208,11 @@ func cmdBatch(app *cli.App, c *cli.Context) error {
 			return err
 		}
 
-		args := persistentArgs("batch", line)
+		args := persistentArgs(line)
 		err2 := app.Run(args) //cli prints error within its func call
+
 		if err2 != nil && c.GlobalBool("mro") {
-			printJSON(err)
+			printJSON(newEr(err2))
 		}
 
 	}
@@ -226,10 +233,10 @@ func cmdConsole(app *cli.App, c *cli.Context) error {
 			return err
 		}
 
-		args := persistentArgs("console", line)
+		args := persistentArgs(line)
 		err2 := app.Run(args) //cli prints error within its func call
 		if err2 != nil && c.GlobalBool("mro") {
-			printJSON(err)
+			printJSON(newEr(err2))
 		}
 	}
 }
@@ -241,16 +248,16 @@ func cmdEcho(c *cli.Context) error {
 		return errors.New("Command echo takes 1 argument")
 	}
 	res := client.EchoSync(args[0])
-	pr := newPR(res, string(res.Data), false)
-	printResponse(c, pr)
+	p := newPr(res, string(res.Data), false)
+	printResponse(c, p)
 	return nil
 }
 
 // Get some info from the application
 func cmdInfo(c *cli.Context) error {
 	res, _, _, _ := client.InfoSync()
-	pr := newPR(res, string(res.Data), false)
-	printResponse(c, pr)
+	p := newPr(res, string(res.Data), false)
+	printResponse(c, p)
 	return nil
 }
 
@@ -261,8 +268,8 @@ func cmdSetOption(c *cli.Context) error {
 		return errors.New("Command set_option takes 2 arguments (key, value)")
 	}
 	res := client.SetOptionSync(args[0], args[1])
-	pr := newPR(res, Fmt("%s=%s", args[0], args[1]), false)
-	printResponse(c, pr)
+	p := newPr(res, Fmt("%s=%s", args[0], args[1]), false)
+	printResponse(c, p)
 	return nil
 }
 
@@ -274,8 +281,8 @@ func cmdAppendTx(c *cli.Context) error {
 	}
 	txBytes := stringOrHexToBytes(c.Args()[0])
 	res := client.AppendTxSync(txBytes)
-	pr := newPR(res, string(res.Data), true)
-	printResponse(c, pr)
+	p := newPr(res, string(res.Data), true)
+	printResponse(c, p)
 	return nil
 }
 
@@ -287,16 +294,16 @@ func cmdCheckTx(c *cli.Context) error {
 	}
 	txBytes := stringOrHexToBytes(c.Args()[0])
 	res := client.CheckTxSync(txBytes)
-	pr := newPR(res, string(res.Data), true)
-	printResponse(c, pr)
+	p := newPr(res, string(res.Data), true)
+	printResponse(c, p)
 	return nil
 }
 
 // Get application Merkle root hash
 func cmdCommit(c *cli.Context) error {
 	res := client.CommitSync()
-	pr := newPR(res, Fmt("0x%X", res.Data), false)
-	printResponse(c, pr)
+	p := newPr(res, Fmt("0x%X", res.Data), false)
+	printResponse(c, p)
 	return nil
 }
 
@@ -308,8 +315,8 @@ func cmdQuery(c *cli.Context) error {
 	}
 	queryBytes := stringOrHexToBytes(c.Args()[0])
 	res := client.QuerySync(queryBytes)
-	pr := newPR(res, string(res.Data), true)
-	printResponse(c, pr)
+	p := newPr(res, string(res.Data), true)
+	printResponse(c, p)
 	return nil
 }
 
@@ -318,23 +325,18 @@ func cmdQuery(c *cli.Context) error {
 func printJSON(v interface{}) {
 	jsonBytes, err := json.Marshal(v)
 	if err != nil {
-		jsonBytes, _ = json.Marshal(err)
+		jsonBytes, _ = json.Marshal(newEr(err))
 	}
 	fmt.Println(string(jsonBytes))
 }
 
-func printResponse(c *cli.Context, pr PR) {
+func printResponse(c *cli.Context, p *pr) {
 
 	verbose := c.GlobalBool("verbose")
 	mro := c.GlobalBool("mro")
 
 	if mro {
-		jsonBytes, err := json.Marshal(pr)
-		if err != nil {
-			jsonBytes, _ = json.Marshal(err)
-		}
-		fmt.Println(string(jsonBytes))
-
+		printJSON(p)
 		return
 	}
 
@@ -342,19 +344,19 @@ func printResponse(c *cli.Context, pr PR) {
 		fmt.Println(">", c.Command.Name, strings.Join(c.Args(), " "))
 	}
 
-	if pr.printCode {
-		fmt.Printf("-> code: %s\n", pr.code)
+	if p.PrintCode {
+		fmt.Printf("-> code: %s\n", p.Code)
 	}
 
 	//if pr.res.Error != "" {
 	//	fmt.Printf("-> error: %s\n", pr.res.Error)
 	//}
 
-	if pr.s != "" {
-		fmt.Printf("-> data: %s\n", pr.s)
+	if p.S != "" {
+		fmt.Printf("-> data: %s\n", p.S)
 	}
-	if pr.res.Log != "" {
-		fmt.Printf("-> log: %s\n", pr.res.Log)
+	if p.Res.Log != "" {
+		fmt.Printf("-> log: %s\n", p.Res.Log)
 	}
 
 	if verbose {

--- a/example/counter/counter.go
+++ b/example/counter/counter.go
@@ -72,14 +72,14 @@ func (app *CounterApplication) Commit() types.Result {
 }
 
 func (app *CounterApplication) Query(query []byte) types.Result {
-	queryStr := string(query[:])
+	queryStr := string(query)
 
 	switch queryStr {
-	case "hashCount":
-		return types.NewResultOK(nil, Fmt("hashCount: %v", app.hashCount))
-	case "txCount":
-		return types.NewResultOK(nil, Fmt("txCount: %v", app.txCount))
+	case "hash":
+		return types.NewResultOK(nil, Fmt("%v", app.hashCount))
+	case "tx":
+		return types.NewResultOK(nil, Fmt("%v", app.txCount))
 	}
 
-	return types.ErrBadNonce.SetLog(Fmt("Invalid nonce. Expected hashCount or txCount, got %v", queryStr))
+	return types.ErrUnknownRequest.SetLog(Fmt("Invalid nonce. Expected hash or tx, got %v", queryStr))
 }

--- a/example/counter/counter.go
+++ b/example/counter/counter.go
@@ -72,5 +72,14 @@ func (app *CounterApplication) Commit() types.Result {
 }
 
 func (app *CounterApplication) Query(query []byte) types.Result {
-	return types.NewResultOK(nil, Fmt("Query is not supported"))
+	queryStr := string(query[:])
+
+	switch queryStr {
+	case "hashCount":
+		return types.NewResultOK(nil, Fmt("hashCount: %v", app.hashCount))
+	case "txCount":
+		return types.NewResultOK(nil, Fmt("txCount: %v", app.txCount))
+	}
+
+	return types.ErrBadNonce.SetLog(Fmt("Invalid nonce. Expected hashCount or txCount, got %v", queryStr))
 }


### PR DESCRIPTION
Fixed flag persistence when using console or batch, no longer exits on error from console or batch. Also added query support for Counter example app (ebuchman request, not an issue)