### PR TITLE
tmsp-cli arg string handling + Make dummy query response values more clear

### DIFF
--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -213,7 +213,11 @@ func cmdAppendTx(c *cli.Context) error {
 	if len(args) != 1 {
 		return errors.New("Command append_tx takes 1 argument")
 	}
-	txBytes := stringOrHexToBytes(c.Args()[0])
+	txBytes, err := stringOrHexToBytes(c.Args()[0])
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
 	res := client.AppendTxSync(txBytes)
 	printResponse(c, res, string(res.Data), true)
 	return nil
@@ -225,7 +229,11 @@ func cmdCheckTx(c *cli.Context) error {
 	if len(args) != 1 {
 		return errors.New("Command check_tx takes 1 argument")
 	}
-	txBytes := stringOrHexToBytes(c.Args()[0])
+	txBytes, err := stringOrHexToBytes(c.Args()[0])
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
 	res := client.CheckTxSync(txBytes)
 	printResponse(c, res, string(res.Data), true)
 	return nil
@@ -244,7 +252,11 @@ func cmdQuery(c *cli.Context) error {
 	if len(args) != 1 {
 		return errors.New("Command query takes 1 argument")
 	}
-	queryBytes := stringOrHexToBytes(c.Args()[0])
+	queryBytes, err := stringOrHexToBytes(c.Args()[0])
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
 	res := client.QuerySync(queryBytes)
 	printResponse(c, res, string(res.Data), true)
 	return nil
@@ -277,21 +289,22 @@ func printResponse(c *cli.Context, res types.Result, s string, printCode bool) {
 }
 
 // NOTE: s is interpreted as a string unless prefixed with 0x
-func stringOrHexToBytes(s string) []byte {
-	if len(s) > 2 && s[:2] == "0x" {
+func stringOrHexToBytes(s string) ([]byte, error) {
+	fmt.Printf("string: %s %x\n", s, []byte(s))
+
+	if len(s) > 2 && strings.ToLower(s[:2]) == "0x" {
 		b, err := hex.DecodeString(s[2:])
 		if err != nil {
-			fmt.Println("Error decoding hex argument:", err.Error())
+			err = fmt.Errorf("Error decoding hex argument: %s", err.Error())
+			return nil, err
 		}
-		return b
+		return b, nil
 	}
 
 	if !strings.HasPrefix(s, "\"") || !strings.HasSuffix(s, "\"") {
-		fmt.Printf("Invalid string arg: \"%s\". Must be quoted or a \"0x\"-prefixed hex string\n", s)
-		return []byte{}
+		err := fmt.Errorf("Invalid string arg: \"%s\". Must be quoted or a \"0x\"-prefixed hex string", s)
+		return nil, err
 	}
 
-	// TODO: return errors
-
-	return []byte(s)
+	return []byte(s[1 : len(s)-1]), nil
 }

--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -285,5 +285,13 @@ func stringOrHexToBytes(s string) []byte {
 		}
 		return b
 	}
+
+	if !strings.HasPrefix(s, "\"") || !strings.HasSuffix(s, "\"") {
+		fmt.Printf("Invalid string arg: \"%s\". Must be quoted or a \"0x\"-prefixed hex string\n", s)
+		return []byte{}
+	}
+
+	// TODO: return errors
+
 	return []byte(s)
 }

--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -215,8 +215,7 @@ func cmdAppendTx(c *cli.Context) error {
 	}
 	txBytes, err := stringOrHexToBytes(c.Args()[0])
 	if err != nil {
-		fmt.Println(err.Error())
-		return nil
+		return err
 	}
 	res := client.AppendTxSync(txBytes)
 	printResponse(c, res, string(res.Data), true)
@@ -231,8 +230,7 @@ func cmdCheckTx(c *cli.Context) error {
 	}
 	txBytes, err := stringOrHexToBytes(c.Args()[0])
 	if err != nil {
-		fmt.Println(err.Error())
-		return nil
+		return err
 	}
 	res := client.CheckTxSync(txBytes)
 	printResponse(c, res, string(res.Data), true)
@@ -254,8 +252,7 @@ func cmdQuery(c *cli.Context) error {
 	}
 	queryBytes, err := stringOrHexToBytes(c.Args()[0])
 	if err != nil {
-		fmt.Println(err.Error())
-		return nil
+		return err
 	}
 	res := client.QuerySync(queryBytes)
 	printResponse(c, res, string(res.Data), true)

--- a/cmd/tmsp-cli/tmsp-cli.go
+++ b/cmd/tmsp-cli/tmsp-cli.go
@@ -290,8 +290,6 @@ func printResponse(c *cli.Context, res types.Result, s string, printCode bool) {
 
 // NOTE: s is interpreted as a string unless prefixed with 0x
 func stringOrHexToBytes(s string) ([]byte, error) {
-	fmt.Printf("string: %s %x\n", s, []byte(s))
-
 	if len(s) > 2 && strings.ToLower(s[:2]) == "0x" {
 		b, err := hex.DecodeString(s[2:])
 		if err != nil {

--- a/example/dummy/dummy.go
+++ b/example/dummy/dummy.go
@@ -49,12 +49,13 @@ func (app *DummyApplication) Commit() types.Result {
 
 func (app *DummyApplication) Query(query []byte) types.Result {
 	index, value, exists := app.state.Get(query)
-	queryResult := QueryResult{index, hex.EncodeToString(value), exists}
+	queryResult := QueryResult{index, string(value), hex.EncodeToString(value), exists}
 	return types.NewResultOK(wire.JSONBytes(queryResult), "")
 }
 
 type QueryResult struct {
-	Index  int    `json:"index"`
-	Value  string `json:"value"`
-	Exists bool   `json:"exists"`
+	Index    int    `json:"index"`
+	Value    string `json:"value"`
+	ValueHex string `json:"valueHex"`
+	Exists   bool   `json:"exists"`
 }

--- a/example/dummy/dummy.go
+++ b/example/dummy/dummy.go
@@ -1,6 +1,7 @@
 package dummy
 
 import (
+	"encoding/hex"
 	"strings"
 
 	. "github.com/tendermint/go-common"
@@ -48,8 +49,7 @@ func (app *DummyApplication) Commit() types.Result {
 
 func (app *DummyApplication) Query(query []byte) types.Result {
 	index, value, exists := app.state.Get(query)
-
-	queryResult := QueryResult{index, string(value), exists}
+	queryResult := QueryResult{index, hex.EncodeToString(value), exists}
 	return types.NewResultOK(wire.JSONBytes(queryResult), "")
 }
 

--- a/tests/test_cli/ex1.tmsp
+++ b/tests/test_cli/ex1.tmsp
@@ -1,10 +1,10 @@
 echo hello
 info
 commit
-append_tx abc
+append_tx "abc"
 info
 commit
-query abc
-append_tx def=xyz
+query "abc"
+append_tx "def=xyz"
 commit
-query def
+query "def"

--- a/tests/test_cli/ex1.tmsp.out
+++ b/tests/test_cli/ex1.tmsp.out
@@ -7,7 +7,7 @@
 > commit 
 -> data: 0x
 
-> append_tx abc
+> append_tx "abc"
 -> code: OK
 
 > info 
@@ -16,17 +16,17 @@
 > commit 
 -> data: 0x750502FC7E84BBD788ED589624F06CFA871845D1
 
-> query abc
+> query "abc"
 -> code: OK
--> data: {"index":0,"value":"abc","exists":true}
+-> data: {"index":0,"value":"abc","valueHex":"616263","exists":true}
 
-> append_tx def=xyz
+> append_tx "def=xyz"
 -> code: OK
 
 > commit 
 -> data: 0x76393B8A182E450286B0694C629ECB51B286EFD5
 
-> query def
+> query "def"
 -> code: OK
--> data: {"index":1,"value":"xyz","exists":true}
+-> data: {"index":1,"value":"xyz","valueHex":"78797a","exists":true}
 


### PR DESCRIPTION
See https://github.com/tendermint/tendermint/issues/346

This PR requires tmsp-cli string arguments to either be quoted strings, or "0x"-prefixed hex strings, for parity with [go-rpc](https://github.com/tendermint/go-rpc/pull/5).

This also adds a `valueHex` field to the dummy query response value, so it goes from this:
```json
{"index":2,"value":"\ufffd\ufffd","exists":true}
```
to this:
```json
{"index":2,"value":"\ufffd\ufffd","valueHex":"abcd","exists":true}
```
This is just to make the output a little more clear to users doing the tutorial who create a hex transaction.